### PR TITLE
Add Ruby POC

### DIFF
--- a/ruby-ffi/Gemfile
+++ b/ruby-ffi/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'ffi'

--- a/ruby-ffi/Gemfile.lock
+++ b/ruby-ffi/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ffi (1.15.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  ffi
+
+BUNDLED WITH
+   2.1.4

--- a/ruby-ffi/example.rb
+++ b/ruby-ffi/example.rb
@@ -1,0 +1,37 @@
+require 'ffi'
+
+# https://github.com/ffi/ffi/blob/master/lib/ffi/platform.rb
+OS_PATH =
+  case FFI::Platform::OS
+  when 'linux'
+    'linux'
+  when 'darwin'
+    'macos'
+  when 'windows'
+    'windows'
+  else
+    raise 'Unsupported operating system'
+  end
+
+CPU_ARCH =
+  case FFI::Platform::ARCH
+  when 'x86_64'
+    'amd64'
+  when 'aarch64'
+    'arm64'
+  else
+    raise 'Unsupported CPU'
+  end
+
+EXT = RbConfig::CONFIG['DLEXT']
+
+module MyLib
+  extend FFI::Library
+  ffi_lib File.join(File.dirname(__FILE__), "../output/#{OS_PATH}/#{CPU_ARCH}/libplugtest.#{EXT}")
+
+  attach_function :toUpper, [ :string ], :void
+end
+
+input = 'Initial value'
+MyLib.toUpper(input)
+p input # "INITIAL VALUE"


### PR DESCRIPTION
I was getting `version 'GLIBC_2.32' not found` error and had to build the `output/linux/amd64/libplugtest.so` myself because I have an older glibc:

```
$ ldd --version
ldd (Ubuntu GLIBC 2.23-0ubuntu11.3) 2.23
```

We might need to build with an older glibc version assuming then it will work on platforms having at least the glibc build version?